### PR TITLE
fix UnicodeDecodeError

### DIFF
--- a/datasource.py
+++ b/datasource.py
@@ -8,7 +8,7 @@ def load_json_files(datasource_name_and_location, verbose=False):
     # Load data into memory (our data is small enough to safely fit in memory)
     scraped_pages = {}
     for name, filepath in datasource_name_and_location:
-        with open(filepath) as json_data:
+        with open(filepath, encoding="utf8") as json_data:
             scraped_pages[name] = json.load(json_data)
 
     if verbose:


### PR DESCRIPTION
Hello Dan - I greatly enjoyed your presentation on Nov 14th (Introduction to Python for Data Science: Coding the Naive Bayes Algorithm). The combination of theory and code was excellent, especially given the format with all of the people.

When I ran your code on my Windows machine, however, I got this:

> runfile('C:/Users/mcram/Documents/Github/Naive-Bayes-Evening-Workshop/run.py', wdir='C:/Users/mcram/Documents/Github/Naive-Bayes-Evening-Workshop')
> Ok let's go!
> Traceback (most recent call last):
>   File "<ipython-input-1-8478e8ecbef0>", line 1, in <module>
>     runfile('C:/Users/mcram/Documents/Github/Naive-Bayes-Evening-Workshop/run.py', wdir='C:/Users/mcram/Documents/Github/Naive-Bayes-Evening-Workshop')
>   File "C:\Users\mcram\Anaconda3\lib\site-packages\spyder\utils\site\sitecustomize.py", line 710, in runfile
>     execfile(filename, namespace)
>   File "C:\Users\mcram\Anaconda3\lib\site-packages\spyder\utils\site\sitecustomize.py", line 101, in execfile
>     exec(compile(f.read(), filename, 'exec'), namespace)
>   File "C:/Users/mcram/Documents/Github/Naive-Bayes-Evening-Workshop/run.py", line 16, in <module>
>     json_text = load_json_files(datasource_info, verbose=True)
>   File "C:\Users\mcram\Documents\Github\Naive-Bayes-Evening-Workshop\datasource.py", line 12, in load_json_files
>     scraped_pages[name] = json.load(json_data, encoding="utf8")
>   File "C:\Users\mcram\Anaconda3\lib\json\__init__.py", line 296, in load
>     return loads(fp.read(),
>   File "C:\Users\mcram\Anaconda3\lib\encodings\cp1252.py", line 23, in decode
>     return codecs.charmap_decode(input,self.errors,decoding_table)[0]
> UnicodeDecodeError: 'charmap' codec can't decode byte 0x8d in position 4562891: character maps to <undefined>

I just now reproduced the error. In my pull request I added `encoding="utf8"` to `open(filepath, encoding="utf8")` in datasource.py in order to avoid the error above. Please let me know if you have any questions.